### PR TITLE
Credhub should start after uaa during a bbr restore

### DIFF
--- a/jobs/credhub/spec
+++ b/jobs/credhub/spec
@@ -14,6 +14,7 @@ templates:
   post-restore-unlock.sh: bin/bbr/post-restore-unlock
   wait-for-stop.sh.erb: bin/bbr/wait-for-stop
   identify-postgres-server-version.erb: bin/bbr/identify-postgres-server-version
+  metadata.erb: bin/bbr/metadata
   # Other scripts
   ctl.erb: bin/ctl
   init_key_stores.erb: bin/init_key_stores.sh

--- a/jobs/credhub/templates/metadata.erb
+++ b/jobs/credhub/templates/metadata.erb
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash 
+
+<% if p("credhub.authentication.uaa.enabled") %>
+echo "---
+restore_should_be_locked_before:
+- job_name: uaa
+  release: uaa"
+
+<% end %>


### PR DESCRIPTION
Hello,

This PR corrects a bbr restore issue when `credhub` uses `uaa`. It ensures that credhub's `post-restore-unlock` is run after `uaa` has started, if `uaa` is enabled in `credhub`.

Since `uaa` is stopped during a bbr restore and `credhub` waits for `uaa` to be started, there is a problem during the bbr restore if the `post-restore-unlock` script is run before `uaa` is started (which is random, based on how you built your deployment manifest).

It fails with:
```
[bbr] 2018/03/13 10:50:55 INFO - Running post-restore-unlock scripts...
[bbr] 2018/03/13 10:50:55 INFO - Unlocking credhub on credhub-uaa/9457f9d6-dbab-4a09-b59d-29b5c23298d2...

[bbr] 2018/03/13 11:00:56 ERROR - Error unlocking credhub on credhub-uaa/9457f9d6-dbab-4a09-b59d-29b5c23298d2.
[bbr] 2018/03/13 11:00:56 INFO - Unlocking uaa on credhub-uaa/9457f9d6-dbab-4a09-b59d-29b5c23298d2...
[bbr] 2018/03/13 11:02:37 INFO - Finished unlocking uaa on credhub-uaa/9457f9d6-dbab-4a09-b59d-29b5c23298d2.
[bbr] 2018/03/13 11:02:37 INFO - Unlocking bbr-atcdb on web/6e8571dd-2f68-4bbd-9764-cf399d4d38c2...
[bbr] 2018/03/13 11:02:37 INFO - Finished unlocking bbr-atcdb on web/6e8571dd-2f68-4bbd-9764-cf399d4d38c2.
[bbr] 2018/03/13 11:02:37 INFO - Finished running post-restore-unlock scripts.
1 error occurred:
error 1:
1 error occurred:
error 1:
Error attempting to run post-restore-unlock for job credhub on credhub-uaa/9457f9d6-dbab-4a09-b59d-29b5c23298d2: monit: action failed -- Other action already in progress -- please try again later
monit: action failed -- Other action already in progress -- please try again later
monit: action failed -- Other action already in progress -- please try again later
monit: action failed -- Other action already in progress -- please try again later
...
```

