### PR TITLE
fixing logic related to bosh link for postgres db

### DIFF
--- a/jobs/credhub/templates/config.json.erb
+++ b/jobs/credhub/templates/config.json.erb
@@ -5,7 +5,7 @@ require 'json'
 config = p("credhub")
 config['bootstrap'] = !!spec.bootstrap
 
-if p("credhub.data_storage.type") == "postgres" && p("credhub.data_storage.host").nil?
+if p("credhub.data_storage.type") == "postgres" && p("credhub.data_storage.host", "").empty?
     if_link("postgres") do |db|
         config["data_storage"]["host"] = db.instances.first.address
         config["data_storage"]["port"] = db.p('databases.port')


### PR DESCRIPTION
The bosh link logic was not working due to a property check for .nil  Resulted in `Error filling in template 'config.json.erb' (line 8: Can't find property '["credhub.data_storage.host"]')`  Tested template with this PR and now able to resolve bosh link if `credhub.data_storage.host` is not set.