### PR TITLE
Misconfigured bosh link in bbr-credhubdb

### DIFF
--- a/jobs/bbr-credhubdb/templates/bbr.json.erb
+++ b/jobs/bbr-credhubdb/templates/bbr.json.erb
@@ -2,7 +2,7 @@
   require 'json'
 
   props = self
-  if_link("credhub_db") { |db| props = db }
+  if_link("postgres") { |db| props = db }
 
   config = {
     username: props.p("credhub.data_storage.username"),


### PR DESCRIPTION
When using bosh links, the backup fails because the json file generated doesn't contain the IP address of the postgres server.
Running `bbr backup` returns this output:
```
1 error occurred:
error 1:
Error attempting to run backup for job bbr-credhubdb on web/8c1276b4-e408-48cf-95a4-044783fd5921: + JOB_PATH=/var/vcap/jobs/bbr-credhubdb
+ SDK_PATH=/var/vcap/jobs/database-backup-restorer
+ BBR_ARTIFACT_FILE_PATH=/var/vcap/store/bbr-backup/bbr-credhubdb//credhubdb_dump
+ CONFIG_PATH=/var/vcap/jobs/bbr-credhubdb/config/bbr.json
+ /var/vcap/jobs/database-backup-restorer/bin/backup --config /var/vcap/jobs/bbr-credhubdb/config/bbr.json --artifact-file /var/vcap/store/bbr-backup/bbr-credhubdb//credhubdb_dump
psql: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
2018/08/07 10:40:37 Unable to check version of Postgres: exit status 2

psql: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/tmp/.s.PGSQL.5432"? - exit code 1
```

The `bbr.json` file generated doesn't contain the IP of the postgres server (in my case in another instance group):
```json
{
  "username": "credhub",
  "password": "mypassword",
  "port": 5432,
  "database": "credhub",
  "adapter": "postgres",
  "tls": {
    "cert": {
      "ca": "-----BEGIN CERTIFICATE-----\nMYCERTIFICATE\n-----END CERTIFICATE-----\n"
    }
  }
}
```