### PR TITLE
Revert "Credhub should start after uaa during a bbr restore"

### DIFF
--- a/jobs/credhub/spec
+++ b/jobs/credhub/spec
@@ -13,7 +13,6 @@ templates:
   post-restore-unlock.sh: bin/bbr/post-restore-unlock
   wait-for-stop.sh.erb: bin/bbr/wait-for-stop
   identify-postgres-server-version.erb: bin/bbr/identify-postgres-server-version
-  metadata.erb: bin/bbr/metadata
   # Other scripts
   ctl.erb: bin/ctl
   init_key_stores.erb: bin/init_key_stores.sh

--- a/jobs/credhub/templates/metadata.erb
+++ b/jobs/credhub/templates/metadata.erb
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash 
-
-<% if p("credhub.authentication.uaa.enabled") %>
-echo "---
-restore_should_be_locked_before:
-- job_name: uaa
-  release: uaa"
-
-<% end %>


### PR DESCRIPTION
We are seeing the following error when trying to backup a credhub deployed alongside a bosh director, reverting this until we figure out a way around that.
`director job 'credhub' specifies locking dependencies, which are not allowed for director jobs`

Reverts pivotal-cf/credhub-release#19