### PR TITLE
bump: Java version to 25

### DIFF
--- a/jobs/credhub/spec
+++ b/jobs/credhub/spec
@@ -52,7 +52,7 @@ templates:
 
 
 packages:
-- openjdk_21.0
+- openjdk_25.0
 - luna-hsm-client-7.4
 - credhub
 

--- a/jobs/credhub/templates/bpm.yml.erb
+++ b/jobs/credhub/templates/bpm.yml.erb
@@ -24,7 +24,7 @@
         'RUN_DIR' => '/var/vcap/data/run/credhub',
         'LOG_DIR' => '/var/vcap/sys/log/credhub',
         'TMP_DIR' => '/var/vcap/data/credhub',
-        'JAVA_HOME' => '/var/vcap/packages/openjdk_21.0/jre',
+        'JAVA_HOME' => '/var/vcap/packages/openjdk_25.0/jre',
         'MAX_HEAP_SIZE' => p('credhub.max_heap_size')
       },
       'additional_volumes' => [

--- a/jobs/credhub/templates/credhub.erb
+++ b/jobs/credhub/templates/credhub.erb
@@ -32,7 +32,7 @@ if p('credhub.data_storage.require_tls') || p('credhub.authentication.uaa.enable
 end
 %>
 
-export JAVA_HOME='/var/vcap/packages/openjdk_21.0/jre'
+export JAVA_HOME='/var/vcap/packages/openjdk_25.0/jre'
 export PATH="$JAVA_HOME/bin:$PATH"
 export JAVA_TOOL_OPTIONS
 

--- a/jobs/credhub/templates/ctl.erb
+++ b/jobs/credhub/templates/ctl.erb
@@ -12,7 +12,7 @@ declare -r max_heap_size=<%= p('credhub.max_heap_size') %>
 
 source $tmp_dir/var-store
 
-export JAVA_HOME=/var/vcap/packages/openjdk_21.0/jre
+export JAVA_HOME=/var/vcap/packages/openjdk_25.0/jre
 export PATH=$JAVA_HOME/bin:$PATH
 
 LOG_DIR=/var/vcap/sys/log/credhub

--- a/jobs/credhub/templates/init_key_stores.erb
+++ b/jobs/credhub/templates/init_key_stores.erb
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ## BEGIN CERTIFICATE INSTALLATION
 
-export JAVA_HOME=/var/vcap/packages/openjdk_21.0/jre
+export JAVA_HOME=/var/vcap/packages/openjdk_25.0/jre
 declare -r tmp_dir=/var/vcap/jobs/credhub/tmp
 
 function generate_password() {

--- a/jobs/credhub/templates/pre-start.erb
+++ b/jobs/credhub/templates/pre-start.erb
@@ -36,7 +36,7 @@ fail_unless_credhub_port_is_open() {
 
 fail_unless_credhub_port_is_open
 
-export JAVA_HOME=/var/vcap/packages/openjdk_21.0/jre
+export JAVA_HOME=/var/vcap/packages/openjdk_25.0/jre
 
 chown -R vcap /var/vcap/jobs/credhub/config
 chmod -R g-rwx,o-rwx /var/vcap/jobs/credhub/config/*

--- a/packages/credhub/spec
+++ b/packages/credhub/spec
@@ -1,6 +1,6 @@
 ---
 name: credhub
 dependencies:
-- openjdk_21.0
+- openjdk_25.0
 files:
 - credhub/**/*

--- a/packages/openjdk_21.0/spec
+++ b/packages/openjdk_21.0/spec
@@ -1,5 +1,0 @@
----
-name: openjdk_21.0
-dependencies: []
-files:
-- openjdk_21.0/bellsoft-jre*.tar.gz

--- a/packages/openjdk_25.0/packaging
+++ b/packages/openjdk_25.0/packaging
@@ -1,14 +1,14 @@
 set -ex
 
 cd ${BOSH_INSTALL_TARGET}
-tar zxvf ${BOSH_COMPILE_TARGET}/openjdk_21.0/bellsoft-jre*.tar.gz
+tar zxvf ${BOSH_COMPILE_TARGET}/openjdk_25.0/bellsoft-jre*.tar.gz
 if [[ $? != 0 ]] ; then
   echo "Cannot unpack JRE"
   exit 1
 fi
 
 #rename directory
-mv jre-21* jre
+mv jre-25* jre
 
 # latest JRE release didn't have correct permissions
 chmod -R a+rx jre

--- a/packages/openjdk_25.0/spec
+++ b/packages/openjdk_25.0/spec
@@ -1,0 +1,5 @@
+---
+name: openjdk_25.0
+dependencies: []
+files:
+- openjdk_25.0/bellsoft-jre*.tar.gz


### PR DESCRIPTION
This change needs to be coordinated with https://github.com/cloudfoundry/credhub/pull/1149 and credhub-oss-ci change.