### PR TITLE
fix: HSM configure_hsm.sh fails on OpenJDK 21 due to removed lib/ext

### DIFF
--- a/jobs/credhub/templates/configure_hsm.erb
+++ b/jobs/credhub/templates/configure_hsm.erb
@@ -32,10 +32,6 @@ EOL
 
 ln -f -s /var/vcap/jobs/credhub/config/encryption.conf /etc/Chrystoki.conf
 
-# JVM 8 - WILL NOT WORK ON JVM 11
-cp /var/vcap/packages/luna-hsm-client-7.4/jsp/LunaProvider.jar $JAVA_HOME/lib/ext/
-cp /var/vcap/packages/luna-hsm-client-7.4/jsp/64/libLunaAPI.so $JAVA_HOME/lib/ext/
-
 <%
   primary_server = hsm_servers.shift
   primary_serial_number = primary_server['partition_serial_number']

--- a/jobs/credhub/templates/credhub.erb
+++ b/jobs/credhub/templates/credhub.erb
@@ -34,6 +34,9 @@ end
 
 <% if p('credhub.encryption.providers').flatten.any? { |provider| provider['type'] == 'hsm' } %>
   JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64"
+  LUNA_CP=":/var/vcap/packages/luna-hsm-client-7.4/jsp/LunaProvider.jar"
+<% else %>
+  LUNA_CP=""
 <% end %>
 
 export JAVA_HOME='/var/vcap/packages/openjdk_25.0/jre'
@@ -41,5 +44,6 @@ export PATH="$JAVA_HOME/bin:$PATH"
 export JAVA_TOOL_OPTIONS
 
 java \
-	-jar "credhub.jar" \
+	-cp "credhub.jar${LUNA_CP}" \
+	org.springframework.boot.loader.launch.JarLauncher \
 	--management.server.port="${MANAGEMENT_SERVER_PORT}"

--- a/jobs/credhub/templates/credhub.erb
+++ b/jobs/credhub/templates/credhub.erb
@@ -32,6 +32,10 @@ if p('credhub.data_storage.require_tls') || p('credhub.authentication.uaa.enable
 end
 %>
 
+<% if p('credhub.encryption.providers').flatten.any? { |provider| provider['type'] == 'hsm' } %>
+  JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64"
+<% end %>
+
 export JAVA_HOME='/var/vcap/packages/openjdk_25.0/jre'
 export PATH="$JAVA_HOME/bin:$PATH"
 export JAVA_TOOL_OPTIONS

--- a/jobs/credhub/templates/ctl.erb
+++ b/jobs/credhub/templates/ctl.erb
@@ -48,6 +48,10 @@ case $1 in
       -Djavax.net.ssl.trustStorePassword=${TRUST_STORE_PASSWORD} \\"
     end
 
+    if p('credhub.encryption.providers').flatten.any? { |provider| provider['type'] == 'hsm' }
+      java_command += "-Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64 \\"
+    end
+
     java_command += "-ea -jar *.jar --management.server.port=" + p('credhub.health_endpoint_port').to_s
     java_command
     %>

--- a/jobs/credhub/templates/ctl.erb
+++ b/jobs/credhub/templates/ctl.erb
@@ -50,9 +50,10 @@ case $1 in
 
     if p('credhub.encryption.providers').flatten.any? { |provider| provider['type'] == 'hsm' }
       java_command += "-Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64 \\"
+      java_command += "-ea -cp credhub.jar:/var/vcap/packages/luna-hsm-client-7.4/jsp/LunaProvider.jar org.springframework.boot.loader.launch.JarLauncher --management.server.port=" + p('credhub.health_endpoint_port').to_s
+    else
+      java_command += "-ea -jar *.jar --management.server.port=" + p('credhub.health_endpoint_port').to_s
     end
-
-    java_command += "-ea -jar *.jar --management.server.port=" + p('credhub.health_endpoint_port').to_s
     java_command
     %>
     ;;

--- a/spec/credhub/credhub_spec.rb
+++ b/spec/credhub/credhub_spec.rb
@@ -55,9 +55,15 @@ describe 'credhub job' do
     end
 
     context 'when no HSM provider is configured' do
-      it 'does not set java.library.path for Luna' do
+      it 'does not reference luna-hsm-client' do
         script = template.render(base_manifest)
         expect(script).not_to include('luna-hsm-client')
+      end
+
+      it 'launches via JarLauncher without a Luna classpath entry' do
+        script = template.render(base_manifest)
+        expect(script).to include('org.springframework.boot.loader.launch.JarLauncher')
+        expect(script).to include('LUNA_CP=""')
       end
     end
 
@@ -66,10 +72,16 @@ describe 'credhub job' do
         script = template.render(hsm_manifest)
         expect(script).to include('-Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64')
       end
+
+      it 'adds LunaProvider.jar to the classpath via -cp' do
+        script = template.render(hsm_manifest)
+        expect(script).to include('LunaProvider.jar')
+        expect(script).to include('org.springframework.boot.loader.launch.JarLauncher')
+      end
     end
 
     context 'when providers is a nested array containing an HSM provider' do
-      it 'sets java.library.path for the Luna native library' do
+      it 'sets java.library.path and adds LunaProvider.jar to the classpath' do
         manifest = {
           'credhub' => {
             'encryption' => {
@@ -100,6 +112,7 @@ describe 'credhub job' do
         }
         script = template.render(manifest)
         expect(script).to include('-Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64')
+        expect(script).to include('LunaProvider.jar')
       end
     end
   end

--- a/spec/credhub/credhub_spec.rb
+++ b/spec/credhub/credhub_spec.rb
@@ -1,0 +1,106 @@
+require 'rspec'
+require 'json'
+require 'yaml'
+require 'bosh/template/test'
+
+describe 'credhub job' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '..', '..')) }
+  let(:job) { release.job('credhub') }
+
+  describe 'bin/credhub template' do
+    let(:template) { job.template('bin/credhub') }
+
+    let(:base_manifest) do
+      {
+        'credhub' => {
+          'encryption' => {
+            'providers' => [
+              {
+                'name' => 'some-internal-provider',
+                'type' => 'internal'
+              }
+            ]
+          }
+        }
+      }
+    end
+
+    let(:hsm_manifest) do
+      {
+        'credhub' => {
+          'encryption' => {
+            'providers' => [
+              {
+                'name' => 'primary',
+                'type' => 'hsm',
+                'connection_properties' => {
+                  'partition' => 'some-partition',
+                  'partition_password' => 'some-partition-password',
+                  'client_certificate' => 'some-client-certificate',
+                  'client_key' => 'some-client-key',
+                  'servers' => [
+                    {
+                      'host' => '10.0.0.1',
+                      'port' => 1792,
+                      'certificate' => 'some-hsm-certificate',
+                      'partition_serial_number' => '123456789'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    end
+
+    context 'when no HSM provider is configured' do
+      it 'does not set java.library.path for Luna' do
+        script = template.render(base_manifest)
+        expect(script).not_to include('luna-hsm-client')
+      end
+    end
+
+    context 'when an HSM provider is configured' do
+      it 'sets java.library.path to the Luna native library directory' do
+        script = template.render(hsm_manifest)
+        expect(script).to include('-Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64')
+      end
+    end
+
+    context 'when providers is a nested array containing an HSM provider' do
+      it 'sets java.library.path for the Luna native library' do
+        manifest = {
+          'credhub' => {
+            'encryption' => {
+              'providers' => [
+                [
+                  {
+                    'name' => 'primary',
+                    'type' => 'hsm',
+                    'connection_properties' => {
+                      'partition' => 'p',
+                      'partition_password' => 'pw',
+                      'client_certificate' => 'cert',
+                      'client_key' => 'key',
+                      'servers' => [
+                        {
+                          'host' => '10.0.0.1',
+                          'port' => 1792,
+                          'certificate' => 'hsm-cert',
+                          'partition_serial_number' => '123'
+                        }
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        }
+        script = template.render(manifest)
+        expect(script).to include('-Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64')
+      end
+    end
+  end
+end

--- a/spec/credhub/ctl_spec.rb
+++ b/spec/credhub/ctl_spec.rb
@@ -1,0 +1,71 @@
+require 'rspec'
+require 'json'
+require 'yaml'
+require 'bosh/template/test'
+
+describe 'credhub job' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '..', '..')) }
+  let(:job) { release.job('credhub') }
+
+  describe 'bin/ctl template' do
+    let(:template) { job.template('bin/ctl') }
+
+    let(:base_manifest) do
+      {
+        'credhub' => {
+          'encryption' => {
+            'providers' => [
+              {
+                'name' => 'some-internal-provider',
+                'type' => 'internal'
+              }
+            ]
+          }
+        }
+      }
+    end
+
+    let(:hsm_manifest) do
+      {
+        'credhub' => {
+          'encryption' => {
+            'providers' => [
+              {
+                'name' => 'primary',
+                'type' => 'hsm',
+                'connection_properties' => {
+                  'partition' => 'some-partition',
+                  'partition_password' => 'some-partition-password',
+                  'client_certificate' => 'some-client-certificate',
+                  'client_key' => 'some-client-key',
+                  'servers' => [
+                    {
+                      'host' => '10.0.0.1',
+                      'port' => 1792,
+                      'certificate' => 'some-hsm-certificate',
+                      'partition_serial_number' => '123456789'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    end
+
+    context 'when no HSM provider is configured' do
+      it 'does not add java.library.path for Luna' do
+        script = template.render(base_manifest)
+        expect(script).not_to include('luna-hsm-client')
+      end
+    end
+
+    context 'when an HSM provider is configured' do
+      it 'passes java.library.path for the Luna native library' do
+        script = template.render(hsm_manifest)
+        expect(script).to include('-Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64')
+      end
+    end
+  end
+end

--- a/spec/credhub/ctl_spec.rb
+++ b/spec/credhub/ctl_spec.rb
@@ -55,9 +55,15 @@ describe 'credhub job' do
     end
 
     context 'when no HSM provider is configured' do
-      it 'does not add java.library.path for Luna' do
+      it 'does not reference luna-hsm-client' do
         script = template.render(base_manifest)
         expect(script).not_to include('luna-hsm-client')
+      end
+
+      it 'launches with -jar' do
+        script = template.render(base_manifest)
+        expect(script).to include('-jar *.jar')
+        expect(script).not_to include('JarLauncher')
       end
     end
 
@@ -65,6 +71,48 @@ describe 'credhub job' do
       it 'passes java.library.path for the Luna native library' do
         script = template.render(hsm_manifest)
         expect(script).to include('-Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64')
+      end
+
+      it 'adds LunaProvider.jar to the classpath via -cp' do
+        script = template.render(hsm_manifest)
+        expect(script).to include('LunaProvider.jar')
+        expect(script).to include('org.springframework.boot.loader.launch.JarLauncher')
+      end
+    end
+
+    context 'when providers is a nested array containing an HSM provider' do
+      it 'sets java.library.path and adds LunaProvider.jar to the classpath' do
+        manifest = {
+          'credhub' => {
+            'encryption' => {
+              'providers' => [
+                [
+                  {
+                    'name' => 'primary',
+                    'type' => 'hsm',
+                    'connection_properties' => {
+                      'partition' => 'p',
+                      'partition_password' => 'pw',
+                      'client_certificate' => 'some-client-certificate',
+                      'client_key' => 'some-client-key',
+                      'servers' => [
+                        {
+                          'host' => '10.0.0.1',
+                          'port' => 1792,
+                          'certificate' => 'hsm-cert',
+                          'partition_serial_number' => '123'
+                        }
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        }
+        script = template.render(manifest)
+        expect(script).to include('-Djava.library.path=/var/vcap/packages/luna-hsm-client-7.4/jsp/64')
+        expect(script).to include('LunaProvider.jar')
       end
     end
   end


### PR DESCRIPTION
- remove code that relies on old of date JVM:
  - The removed code even has comment saying so: "JVM 8 - WILL NOT WORK ON JVM 11"

- The Java Extension Mechanism (lib/ext directory) was permanently removed in JEP 220 (Java 9). The configure_hsm.sh script was copying Luna HSM JSP libraries to $JAVA_HOME/lib/ext/, causing the pre-start hook to crash on the current openjdk_21.0 stemcell.

- Remove the broken cp commands and instead set java.library.path via JAVA_TOOL_OPTIONS so the Luna native library is discoverable when an HSM encryption provider is configured.
  - for native .so loading — this is the standard Luna/PKCS#11 pattern on JDK 9+.

TNZ-112110
ai-assisted=yes