### PR TITLE
fix: HSM configure_hsm.sh fails on OpenJDK 21 due to removed lib/ext

### DIFF
--- a/jobs/credhub/templates/configure_hsm.erb
+++ b/jobs/credhub/templates/configure_hsm.erb
@@ -32,10 +32,6 @@ EOL
 
 ln -f -s /var/vcap/jobs/credhub/config/encryption.conf /etc/Chrystoki.conf
 
-# JVM 8 - WILL NOT WORK ON JVM 11
-cp /var/vcap/packages/luna-hsm-client-7.4/jsp/LunaProvider.jar $JAVA_HOME/lib/ext/
-cp /var/vcap/packages/luna-hsm-client-7.4/jsp/64/libLunaAPI.so $JAVA_HOME/lib/ext/
-
 <%
   primary_server = hsm_servers.shift
   primary_serial_number = primary_server['partition_serial_number']


### PR DESCRIPTION
- remove code that relies on old of date JVM:
  - The removed code even has comment saying so: "JVM 8 - WILL NOT WORK ON JVM 11"

- The Java Extension Mechanism (lib/ext directory) was permanently removed in JEP 220 (Java 9). The configure_hsm.sh script was copying Luna HSM JSP libraries to $JAVA_HOME/lib/ext/, causing the pre-start script to crash.

TNZ-112110
ai-assisted=yes